### PR TITLE
Allow disabling undocumented API diagnostics

### DIFF
--- a/docs/configuration-examples.md
+++ b/docs/configuration-examples.md
@@ -95,6 +95,7 @@ The extension automatically detects `buf.yaml` files - no additional configurati
   "protobuf.diagnostics.deprecatedUsage": true,
   "protobuf.diagnostics.unusedSymbols": true,
   "protobuf.diagnostics.circularDependencies": true,
+  "protobuf.diagnostics.documentationComments": true,
   "protobuf.diagnostics.severity.namingConventions": "error",
   "protobuf.diagnostics.severity.referenceErrors": "error",
   "protobuf.diagnostics.severity.fieldTagIssues": "error"
@@ -193,6 +194,7 @@ The extension automatically detects `buf.yaml` files - no additional configurati
   "protobuf.diagnostics.discouragedConstructs": true,
   "protobuf.diagnostics.deprecatedUsage": true,
   "protobuf.diagnostics.circularDependencies": true,
+  "protobuf.diagnostics.documentationComments": true,
   "protobuf.diagnostics.severity.namingConventions": "warning",
   "protobuf.diagnostics.severity.referenceErrors": "error",
   "protobuf.diagnostics.severity.fieldTagIssues": "error",

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -221,6 +221,14 @@ service UserService {
 }
 ```
 
+**Configuration:**
+
+```jsonc
+{
+  "protobuf.diagnostics.documentationComments": true
+}
+```
+
 ## Severity Levels
 
 You can configure the severity of different diagnostic categories:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -73,6 +73,12 @@ Settings can be configured in:
 - **Default**: `true`
 - **Description**: Detect circular import dependencies
 
+#### `protobuf.diagnostics.documentationComments`
+
+- **Type**: `boolean`
+- **Default**: `true`
+- **Description**: Detect undocumented APIs
+
 #### Severity Settings
 
 ##### `protobuf.diagnostics.severity.namingConventions`
@@ -527,6 +533,7 @@ Settings support VS Code-style variables in path settings (`protobuf.protoc.path
   "protobuf.diagnostics.namingConventions": true,
   "protobuf.diagnostics.deprecatedUsage": true,
   "protobuf.diagnostics.circularDependencies": true,
+  "protobuf.diagnostics.documentationComments": true,
 
   // Formatter
   "protobuf.formatterEnabled": true,

--- a/package.json
+++ b/package.json
@@ -241,6 +241,11 @@
           "default": true,
           "description": "Detect circular import dependencies"
         },
+        "protobuf.diagnostics.documentationComments": {
+          "type": "boolean",
+          "default": true,
+          "description": "Detect undocumented APIs"
+        },
         "protobuf.diagnostics.severity.namingConventions": {
           "type": "string",
           "enum": [

--- a/src/server/diagnostics.enhanced.test.ts
+++ b/src/server/diagnostics.enhanced.test.ts
@@ -309,8 +309,10 @@ service UserService {
       const uri = 'file:///test.proto';
       const file = parser.parse(content, uri);
       analyzer.updateFile(uri, file);
-
+      
+      diagnosticsProvider.updateSettings({ documentationComments: true });
       const diags = diagnosticsProvider.validate(uri, file, content);
+
       // Documentation validation would check for comments
       expect(diags.length).toBeGreaterThanOrEqual(0);
     });

--- a/src/server/providers/diagnostics.ts
+++ b/src/server/providers/diagnostics.ts
@@ -40,6 +40,7 @@ export interface DiagnosticsSettings {
   deprecatedUsage: boolean;
   unusedSymbols: boolean;
   circularDependencies: boolean;
+  documentationComments: boolean;
 }
 
 const DEFAULT_SETTINGS: DiagnosticsSettings = {
@@ -51,7 +52,8 @@ const DEFAULT_SETTINGS: DiagnosticsSettings = {
   discouragedConstructs: true,
   deprecatedUsage: true,
   unusedSymbols: false, // Off by default as it can be noisy
-  circularDependencies: true
+  circularDependencies: true,
+  documentationComments: true
 };
 
 export class DiagnosticsProvider {
@@ -159,7 +161,9 @@ export class DiagnosticsProvider {
     this.validateProto3FieldPresence(uri, file, diagnostics);
 
     // Validate documentation comments
-    this.validateDocumentationComments(uri, file, diagnostics);
+    if (this.settings.documentationComments) {
+      this.validateDocumentationComments(uri, file, diagnostics);
+    }
 
     return diagnostics;
   }

--- a/src/server/utils/configManager.test.ts
+++ b/src/server/utils/configManager.test.ts
@@ -104,7 +104,8 @@ describe('ConfigManager', () => {
       discouragedConstructs: settings.protobuf.diagnostics.discouragedConstructs,
       deprecatedUsage: true,
       unusedSymbols: false,
-      circularDependencies: true
+      circularDependencies: true,
+      documentationComments: true
     });
   });
 
@@ -514,7 +515,8 @@ describe('ConfigManager', () => {
           ...defaultSettings.protobuf.diagnostics,
           deprecatedUsage: undefined as any,
           unusedSymbols: undefined as any,
-          circularDependencies: undefined as any
+          circularDependencies: undefined as any,
+          documentationComments: undefined as any
         }
       }
     };
@@ -537,7 +539,8 @@ describe('ConfigManager', () => {
       expect.objectContaining({
         deprecatedUsage: true,
         unusedSymbols: false,
-        circularDependencies: true
+        circularDependencies: true,
+        documentationComments: true
       })
     );
   });

--- a/src/server/utils/configManager.ts
+++ b/src/server/utils/configManager.ts
@@ -167,7 +167,8 @@ export function updateProvidersWithSettings(
     discouragedConstructs: diag.discouragedConstructs,
     deprecatedUsage: diag.deprecatedUsage ?? true,
     unusedSymbols: diag.unusedSymbols ?? false,
-    circularDependencies: diag.circularDependencies ?? true
+    circularDependencies: diag.circularDependencies ?? true,
+    documentationComments: diag.documentationComments ?? true
   };
   diagnosticsProvider.updateSettings(diagSettings);
   logger.info(`Diagnostics settings: enabled=${diag.enabled}, fieldTagChecks=${diagSettings.fieldTagChecks}, duplicateFieldChecks=${diagSettings.duplicateFieldChecks}`);

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -40,6 +40,7 @@ export interface Settings {
       deprecatedUsage: boolean;
       unusedSymbols: boolean;
       circularDependencies: boolean;
+      documentationComments: boolean;
       severity: {
         namingConventions: string;
         referenceErrors: string;
@@ -128,6 +129,7 @@ export const defaultSettings: Settings = {
       deprecatedUsage: true,
       unusedSymbols: false,
       circularDependencies: true,
+      documentationComments: true,
       severity: {
         namingConventions: 'warning',
         referenceErrors: 'error',


### PR DESCRIPTION
Adds a `protobuf.diagnostics.documentationComments` setting (defaulted to `true`) to disable messages about undocumented APIs, similar to other existing diagnostics. I already use api-linter scoped to specific files for these messages; I don't want this extension to handle these for me. 