### PR TITLE
Support multi-line RPC definitions.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,9 @@
 {
-  "protobuf.buf.path": "/opt/homebrew/bin/buf",
-  "protobuf.protoc.path": "/opt/homebrew/bin/protoc",
   "protobuf.includes": ["${workspaceFolder}/examples/buf/.buf-deps"],
   "protobuf.formatter.alignFields": false,
   // Use buf linter instead of protoc
   "protobuf.externalLinter.enabled": true,
   "protobuf.externalLinter.linter": "buf",
-  "protobuf.externalLinter.bufPath": "/opt/homebrew/bin/buf",
   "protobuf.externalLinter.runOnSave": true,
 
   // Code generation on save
@@ -47,6 +44,5 @@
   "search.exclude": {
     "out": true
   },
-  "typescript.tsc.autoDetect": "off",
-  "protobuf.clangFormat.path": "/opt/homebrew/bin/clang-format"
+  "typescript.tsc.autoDetect": "off"
 }

--- a/examples/regressions/textmate-grammar/proto3_features.proto
+++ b/examples/regressions/textmate-grammar/proto3_features.proto
@@ -272,6 +272,16 @@ service Proto3Service {
 	rpc SafeMethod (Request) returns (Response) {
 		option idempotency_level = NO_SIDE_EFFECTS;
 	}
+
+  // RPC with a very long method name.
+	rpc VeryLongMethodNameThatCausesTheDefinitionToOverflow (Request)
+	    returns (Response);
+
+  // RPC with a very long method name and no side effects.
+	rpc SafeVeryLongMethodNameThatCausesTheDefinitionToOverflow (Request)
+		returns (Response) {
+		option idempotency_level = NO_SIDE_EFFECTS;
+	}
 }
 
 message Request {

--- a/syntaxes/__tests__/services.proto.test
+++ b/syntaxes/__tests__/services.proto.test
@@ -26,4 +26,34 @@ service Greeter {
   rpc WithOptions (Request) returns (Response) {
 //                                             ^ punctuation.definition.block.proto
   }
+
+  rpc WithLineBreak (Request)
+//^^^ keyword.declaration.rpc.proto
+//    ^^^^^^^^^^^^^ entity.name.function.rpc.proto
+//                   ^^^^^^^ entity.name.type.proto
+      returns (Response);
+//    ^^^^^^^ keyword.control.returns.proto
+//             ^^^^^^^^ entity.name.type.proto
+                        ^ punctuation.terminator.proto
+
+  rpc WithLineBreak (stream Request)
+//^^^ keyword.declaration.rpc.proto
+//    ^^^^^^^^^^^^^ entity.name.function.rpc.proto
+//                   ^^^^^^ keyword.other.stream.proto
+//                          ^^^^^^^ entity.name.type.proto
+      returns (stream Response);
+//    ^^^^^^^ keyword.control.returns.proto
+//             ^^^^^^ keyword.other.stream.proto
+//                    ^^^^^^^^ entity.name.type.proto
+                               ^ punctuation.terminator.proto
+
+  rpc WithLineBreak (Request)
+//^^^ keyword.declaration.rpc.proto
+//    ^^^^^^^^^^^^^ entity.name.function.rpc.proto
+//                   ^^^^^^^ entity.name.type.proto
+      returns (Response) {
+//    ^^^^^^^ keyword.control.returns.proto
+//             ^^^^^^^^ entity.name.type.proto
+//                       ^ punctuation.definition.block.proto
+  }
 }

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -597,37 +597,48 @@
         }
       ]
     },
+    "rpc_keywords": {
+      "patterns": [
+        {
+          "comment": "RPC request type definition",
+          "match": "\\(\\s*(stream)?\\s*([\\w.]+)\\s*\\)",
+          "captures": {
+            "1": { "name": "keyword.other.stream.proto" },
+            "2": { "name": "entity.name.type.proto" }
+          }
+        },
+        {
+          "comment": "RPC return type definition",
+          "match": "\\s+(returns)\\s+",
+          "captures": {
+            "1": { "name": "keyword.control.returns.proto" }
+          }
+        },
+        {
+          "comment": "opening brace for options block",
+          "match": "(\\{)",
+          "name": "punctuation.definition.block.proto"
+        }
+      ]
+    },
     "rpc": {
       "patterns": [
         {
-          "comment": "RPC with option body",
-          "begin": "\\b(rpc)\\s+(\\w+)\\s*\\(\\s*(stream)?\\s*([\\w.]+)\\s*\\)\\s*(returns)\\s*\\(\\s*(stream)?\\s*([\\w.]+)\\s*\\)\\s*(\\{)",
-          "end": "\\}",
+          "comment": "RPC with multi-line definition",
+          "begin": "(rpc)\\s+(\\w+)",
+          "end": "\\}|(;)",
           "beginCaptures": {
             "1": { "name": "keyword.declaration.rpc.proto" },
-            "2": { "name": "entity.name.function.rpc.proto" },
-            "3": { "name": "keyword.other.stream.proto" },
-            "4": { "name": "entity.name.type.proto" },
-            "5": { "name": "keyword.control.returns.proto" },
-            "6": { "name": "keyword.other.stream.proto" },
-            "7": { "name": "entity.name.type.proto" },
-            "8": { "name": "punctuation.definition.block.proto" }
+            "2": { "name": "entity.name.function.rpc.proto" }
           },
-          "patterns": [{ "include": "#comments" }, { "include": "#option" }]
-        },
-        {
-          "comment": "RPC without body (ending with semicolon)",
-          "match": "\\b(rpc)\\s+(\\w+)\\s*\\(\\s*(stream)?\\s*([\\w.]+)\\s*\\)\\s*(returns)\\s*\\(\\s*(stream)?\\s*([\\w.]+)\\s*\\)\\s*(;)",
-          "captures": {
-            "1": { "name": "keyword.declaration.rpc.proto" },
-            "2": { "name": "entity.name.function.rpc.proto" },
-            "3": { "name": "keyword.other.stream.proto" },
-            "4": { "name": "entity.name.type.proto" },
-            "5": { "name": "keyword.control.returns.proto" },
-            "6": { "name": "keyword.other.stream.proto" },
-            "7": { "name": "entity.name.type.proto" },
-            "8": { "name": "punctuation.terminator.proto" }
-          }
+          "endCaptures": {
+            "1": { "name": "punctuation.terminator.proto" }
+          },
+          "patterns": [
+            { "include": "#rpc_keywords" },
+            { "include": "#comments" },
+            { "include": "#option" }
+          ]
         }
       ]
     },


### PR DESCRIPTION
RPC definitions can split over multiple lines, commonly breaking before the `returns` keyword. This caused highlighting to fail outright because RPC definition matching was done using `match`. This change switches matching for RPCs to `begin`/`end` and uses smaller submatches for keywords.

I also removed paths from the checked in configuration since they're system specific. Paths seem like something that should be configured in user settings and not workspace settings.