### PR TITLE
Implement diagnostic severity support.

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -238,7 +238,8 @@ You can configure the severity of different diagnostic categories:
   "protobuf.diagnostics.severity.namingConventions": "warning",
   "protobuf.diagnostics.severity.referenceErrors": "error",
   "protobuf.diagnostics.severity.fieldTagIssues": "error",
-  "protobuf.diagnostics.severity.discouragedConstructs": "warning"
+  "protobuf.diagnostics.severity.discouragedConstructs": "warning",
+  "protobuf.diagnostics.severity.nonCanonicalImportPath": "error"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -363,6 +363,17 @@
           "default": "warning",
           "description": "Severity level for discouraged constructs"
         },
+        "protobuf.diagnostics.severity.nonCanonicalImportPath": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint"
+          ],
+          "default": "error",
+          "description": "Severity level for reporting of a non-canonical import path"
+        },
         "protobuf.completion.autoImport": {
           "type": "boolean",
           "default": true,
@@ -861,7 +872,7 @@
       ]
     }
   },
-   "scripts": {
+  "scripts": {
     "pretest": "node -e \"require('fs').mkdirSync('.vscode-test',{recursive:true});\"",
     "vscode:prepublish": "npm run compile && npm run build:tree-sitter",
     "compile": "tsc -b",

--- a/src/server/providers/__tests__/diagnostics/diagnostics.severity.test.ts
+++ b/src/server/providers/__tests__/diagnostics/diagnostics.severity.test.ts
@@ -1,0 +1,57 @@
+import { DiagnosticsProvider } from "../../diagnostics";
+import { ProtoParser } from "../../../core/parser";
+import { SemanticAnalyzer } from "../../../core/analyzer";
+import { GOOGLE_WELL_KNOWN_PROTOS } from "../../../utils/googleWellKnown";
+import { DiagnosticSeverity } from "vscode-languageserver/node";
+import { DEFAULT_DIAGNOSTICS_SEVERITY_SETTINGS } from "../../diagnostics/types";
+
+describe("DiagnosticsProvider severity", () => {
+  const parser = new ProtoParser();
+  const analyzer = new SemanticAnalyzer();
+  const diagnosticsProvider = new DiagnosticsProvider(analyzer);
+
+  beforeAll(() => {
+    // Preload minimal google.type.Date stub
+    const dateContent = GOOGLE_WELL_KNOWN_PROTOS["google/type/date.proto"];
+    const dateUri = "builtin:///google/type/date.proto";
+    analyzer.updateFile(dateUri, parser.parse(dateContent, dateUri));
+  });
+
+  describe("nonCanonicalImportPath", () => {
+    const content = `syntax = "proto3";
+      import "date.proto";
+      
+      message Sample {
+        google.type.Date date = 1;
+      }`;
+    const uri = "file:///sample_wrong_import.proto";
+    const file = parser.parse(content, uri);
+    analyzer.updateFile(uri, file);
+
+    it("reports non-canonical import path at default severity", () => {
+      const diags = diagnosticsProvider.validate(uri, file);
+      const wrongImport = diags.find((d) =>
+        d.message.includes("should be imported via")
+      );
+
+      expect(wrongImport).toBeDefined();
+      expect(wrongImport?.severity).toBe(DiagnosticSeverity.Error);
+    });
+
+    it("reports non-canonical import path at specified severity", () => {
+      diagnosticsProvider.updateSettings({
+        severity: {
+          ...DEFAULT_DIAGNOSTICS_SEVERITY_SETTINGS,
+          nonCanonicalImportPath: "hint",
+        },
+      });
+      const diags = diagnosticsProvider.validate(uri, file);
+      const wrongImport = diags.find((d) =>
+        d.message.includes("should be imported via")
+      );
+
+      expect(wrongImport).toBeDefined();
+      expect(wrongImport?.severity).toBe(DiagnosticSeverity.Hint);
+    });
+  });
+});

--- a/src/server/providers/diagnostics/types.ts
+++ b/src/server/providers/diagnostics/types.ts
@@ -3,7 +3,30 @@
  */
 
 import { DiagnosticSeverity } from 'vscode-languageserver/node';
+import type { SeveritySetting } from '../../utils/types';
 
+/**
+ * Settings for severities of diagnostic settings
+ */
+export interface DiagnosticsSeveritySettings {
+  namingConventions: SeveritySetting;
+  referenceErrors: SeveritySetting;
+  fieldTagIssues: SeveritySetting;
+  discouragedConstructs: SeveritySetting;
+  nonCanonicalImportPath: SeveritySetting;
+}
+
+/**
+ * Default severity settings
+ */
+export const DEFAULT_DIAGNOSTICS_SEVERITY_SETTINGS: DiagnosticsSeveritySettings = {
+    namingConventions: 'warning',
+    referenceErrors: 'error',
+    fieldTagIssues: 'error',
+    discouragedConstructs: 'warning',
+    nonCanonicalImportPath: 'error',
+};
+  
 /**
  * Settings for controlling which diagnostics are enabled
  */
@@ -19,6 +42,7 @@ export interface DiagnosticsSettings {
   circularDependencies: boolean;
   documentationComments: boolean;
   editionFeatures: boolean;
+  severity: DiagnosticsSeveritySettings;
 }
 
 /**
@@ -35,7 +59,8 @@ export const DEFAULT_DIAGNOSTICS_SETTINGS: DiagnosticsSettings = {
   unusedSymbols: false,
   circularDependencies: true,
   documentationComments: true,
-  editionFeatures: true
+  editionFeatures: true,
+  severity: DEFAULT_DIAGNOSTICS_SEVERITY_SETTINGS,
 };
 
 /**
@@ -61,9 +86,9 @@ export function isExternalDependencyFile(uri: string): boolean {
 /**
  * Diagnostic severity helpers
  */
-export const Severity = {
-  Error: DiagnosticSeverity.Error,
-  Warning: DiagnosticSeverity.Warning,
-  Information: DiagnosticSeverity.Information,
-  Hint: DiagnosticSeverity.Hint
-} as const;
+export const Severity: { [sev in SeveritySetting]: DiagnosticSeverity } = {
+  error: DiagnosticSeverity.Error,
+  warning: DiagnosticSeverity.Warning,
+  information: DiagnosticSeverity.Information,
+  hint: DiagnosticSeverity.Hint,
+};

--- a/src/server/utils/__tests__/configManager.test.ts
+++ b/src/server/utils/__tests__/configManager.test.ts
@@ -113,7 +113,14 @@ describe('ConfigManager', () => {
       deprecatedUsage: true,
       unusedSymbols: false,
       circularDependencies: true,
-      documentationComments: true
+      documentationComments: true,
+      severity: {
+        discouragedConstructs: settings.protobuf.diagnostics.severity.discouragedConstructs,
+        fieldTagIssues: settings.protobuf.diagnostics.severity.fieldTagIssues,
+        namingConventions: settings.protobuf.diagnostics.severity.namingConventions,
+        referenceErrors: settings.protobuf.diagnostics.severity.referenceErrors,
+        nonCanonicalImportPath: settings.protobuf.diagnostics.severity.nonCanonicalImportPath,
+      },
     });
   });
 

--- a/src/server/utils/configManager.ts
+++ b/src/server/utils/configManager.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { LogLevel } from './logger';
 import { logger } from './logger';
 import type { Settings } from './types';
-import type { DiagnosticsProvider } from '../providers/diagnostics';
+import type { DiagnosticsProvider, DiagnosticsSettings } from '../providers/diagnostics';
 import type { ProtoFormatter } from '../providers/formatter';
 import type { RenumberProvider } from '../providers/renumber';
 import type { SemanticAnalyzer } from '../core/analyzer';
@@ -178,7 +178,7 @@ export function updateProvidersWithSettings(
 ): { includePaths: string[]; protoSrcsDir: string } {
   // Update diagnostics settings
   const diag = settings.protobuf.diagnostics;
-  const diagSettings = {
+  const diagSettings: Partial<DiagnosticsSettings> = {
     namingConventions: diag.namingConventions,
     referenceChecks: diag.referenceChecks,
     importChecks: diag.importChecks,
@@ -188,10 +188,17 @@ export function updateProvidersWithSettings(
     deprecatedUsage: diag.deprecatedUsage ?? true,
     unusedSymbols: diag.unusedSymbols ?? false,
     circularDependencies: diag.circularDependencies ?? true,
-    documentationComments: diag.documentationComments ?? true
+    documentationComments: diag.documentationComments ?? true,
+    severity: {
+      namingConventions: diag.severity.namingConventions,
+      referenceErrors: diag.severity.referenceErrors,
+      fieldTagIssues: diag.severity.fieldTagIssues,
+      discouragedConstructs: diag.severity.discouragedConstructs,
+      nonCanonicalImportPath: diag.severity.nonCanonicalImportPath,
+    },
   };
   diagnosticsProvider.updateSettings(diagSettings);
-  logger.info(`Diagnostics settings: enabled=${diag.enabled}, fieldTagChecks=${diagSettings.fieldTagChecks}, duplicateFieldChecks=${diagSettings.duplicateFieldChecks}`);
+  logger.info(`Diagnostics settings:\n${JSON.stringify(diagSettings, null, 2)}`);
 
   // Update formatter settings
   const formatterSettings = {

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -6,6 +6,11 @@
 import { DEFAULT_CONFIG } from './constants';
 
 /**
+ * Setting value for a severity
+ */
+export type SeveritySetting = 'error' | 'warning' | 'information' | 'hint';
+
+/**
  * Configuration settings for the Protobuf extension
  */
 export interface Settings {
@@ -49,10 +54,11 @@ export interface Settings {
       circularDependencies: boolean;
       documentationComments: boolean;
       severity: {
-        namingConventions: string;
-        referenceErrors: string;
-        fieldTagIssues: string;
-        discouragedConstructs: string;
+        namingConventions: SeveritySetting;
+        referenceErrors: SeveritySetting;
+        fieldTagIssues: SeveritySetting;
+        discouragedConstructs: SeveritySetting;
+        nonCanonicalImportPath: SeveritySetting;
       };
     };
     completion: {
@@ -157,7 +163,8 @@ export const defaultSettings: Settings = {
         namingConventions: 'warning',
         referenceErrors: 'error',
         fieldTagIssues: 'error',
-        discouragedConstructs: 'warning'
+        discouragedConstructs: 'warning',
+        nonCanonicalImportPath: 'error',
       }
     },
     completion: {


### PR DESCRIPTION
Unless I overlooked something, all the `diagnostics.severity.*` settings were not being used anywhere. This change wires them up to actually influence the error types being reported.

Also adds a new severity control for the non-canonical import paths. This describes the "should be imported via" errors, which are shown if the import path of a proto does not match the "suggested" one. We use this plugin with Bazel, so our import paths are not the ones the extension (or protoc) would normally expect.