### PR TITLE
fix: prevent proto options explorer from opening on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -980,7 +980,8 @@
           "icon": "resources/protobuf-icon.svg",
           "id": "protobufOptionInspector",
           "name": "Proto Options",
-          "when": "protobuf.optionInspector.visible"
+          "when": "protobuf.optionInspector.visible",
+          "visibility": "collapsed"
         }
       ]
     },

--- a/src/client/sidebar/protobufSidebarProvider.ts
+++ b/src/client/sidebar/protobufSidebarProvider.ts
@@ -417,18 +417,13 @@ export function registerProtobufSidebar(
 ): ProtobufSidebarProvider {
   const sidebarProvider = new ProtobufSidebarProvider(context, betaFeaturesEnabled);
 
-  const treeView = vscode.window.createTreeView('protobufExplorer', {
-    treeDataProvider: sidebarProvider,
-    showCollapseAll: true,
-  });
-
   context.subscriptions.push(
+    // Register lazily so VS Code does not need to instantiate the custom view during startup.
+    vscode.window.registerTreeDataProvider('protobufExplorer', sidebarProvider),
     vscode.commands.registerCommand('protobuf.sidebar.refresh', () => {
       sidebarProvider.refresh();
     })
   );
-
-  context.subscriptions.push(treeView);
 
   return sidebarProvider;
 }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -259,6 +259,15 @@ describe('Extension Activation', () => {
     expect(mockVscode.commands.registerCommand).toHaveBeenCalled();
   });
 
+  it('should register the protobuf explorer without eagerly creating the tree view', async () => {
+    mockVscode.window.createOutputChannel.mockReturnValue(createTestOutputChannel());
+
+    await activate(mockExtensionContext as any);
+
+    expect(mockVscode.window.registerTreeDataProvider).toHaveBeenCalledWith('protobufExplorer', expect.anything());
+    expect(mockVscode.window.createTreeView).not.toHaveBeenCalled();
+  });
+
   it('should initialize option inspector visibility context from active editor', async () => {
     mockVscode.window.createOutputChannel.mockReturnValue(createTestOutputChannel());
     mockVscode.window.activeTextEditor = undefined as any;
@@ -296,6 +305,22 @@ describe('Extension Activation', () => {
       'protobuf.optionInspector.visible',
       true
     );
+  });
+
+  it('should keep the proto options explorer collapsed by default in the manifest', () => {
+    const manifest = require('../package.json') as {
+      contributes: {
+        views: {
+          explorer: Array<{ id: string; when?: string; visibility?: string }>;
+        };
+      };
+    };
+
+    const optionInspectorView = manifest.contributes.views.explorer.find(view => view.id === 'protobufOptionInspector');
+
+    expect(optionInspectorView).toBeDefined();
+    expect(optionInspectorView?.when).toBe('protobuf.optionInspector.visible');
+    expect(optionInspectorView?.visibility).toBe('collapsed');
   });
 
   it('should setup file system watchers', async () => {


### PR DESCRIPTION
Resolves https://github.com/DrBlury/protobuf-vsc-extension/issues/108