### PR TITLE
Fix filename-only proto import matching

### DIFF
--- a/src/server/core/analyzer.ts
+++ b/src/server/core/analyzer.ts
@@ -246,8 +246,8 @@ export class SemanticAnalyzer {
   private doesFileMatchImport(normalizedUri: string, importPath: string): boolean {
     const normalizedImport = importPath.replace(/\\/g, '/');
 
-    // Direct suffix match (most common case)
-    if (normalizedUri.endsWith('/' + normalizedImport) || normalizedUri.endsWith(normalizedImport)) {
+    // Match imports that include a relative path, like "foo/bar.proto"
+    if (normalizedImport.includes('/') && normalizedUri.endsWith(`/${normalizedImport}`)) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

Fixes a false positive in proto import resolution for filename-only imports

Previously, a bare import such as:

    import "common.proto";

could incorrectly match a file like:

    foo_common.proto

because the resolver allowed suffix matching for filename-only imports.

## Fix

Filename-only imports now match by exact basename. Path-based matching is still used only when the import includes a relative path.

## Result

This prevents incorrect navigation and false diagnostics, including circular dependency warnings caused by resolving an import to the wrong file.